### PR TITLE
Document Optional/Get-InstalledApps.ps1 usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Run as needed.
 Allows the admin user to quickly answer questions about newly found applications (from the Security Report) to get all of the columns filled in for the application.
 This has been replaced with the web GUI but can still be used.
 
+Optional/Get-InstalledApps.ps1:
+Optional software crawler for small deployments. Run locally (or via scheduled task) on each workstation to collect installed applications and write them to the `smcrawler` table in MySQL.
+Requires the MySQL .NET connector and access to `smapp.ini` for database credentials. The script will attempt to locate `smapp.ini` in the parent folder if it is run from the `Optional` directory.
+Use this when you do not have a separate inventory source (e.g., PDQ) to generate the CSV for `IngestCSV.vbs`.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Updating

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Optional/Get-InstalledApps.ps1:
 Optional software crawler for small deployments. Run locally (or via scheduled task) on each workstation to collect installed applications and write them to the `smcrawler` table in MySQL.
 Requires the MySQL .NET connector and access to `smapp.ini` for database credentials. The script will attempt to locate `smapp.ini` in the parent folder if it is run from the `Optional` directory.
 Use this when you do not have a separate inventory source (e.g., PDQ) to generate the CSV for `IngestCSV.vbs`.
+Quick start:
+1. Ensure the MySQL .NET connector is installed on the workstation.
+2. Copy `smapp.ini` from the main install directory (or create it) and confirm the `[Database]` settings.
+3. Run `Optional/Get-InstalledApps.ps1` locally or schedule it to run daily on each workstation.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -91,7 +95,7 @@ Updating is simple using git:
 <!-- ROADMAP -->
 ## Roadmap
 
-- [ ] Create a software crawler or agent for small deployments
+- [x] Create a software crawler or agent for small deployments (see `Optional/Get-InstalledApps.ps1`)
 - [ ] Better code documentation
 - [ ] Create and Integrate WhatTheFOSS list
 


### PR DESCRIPTION
### Motivation
- Add documentation for the optional PowerShell software crawler so operators know its purpose, configuration expectations, and when to use it for small deployments.

### Description
- Inserted a `Usage` entry for `Optional/Get-InstalledApps.ps1` describing that it writes to the `smcrawler` MySQL table, requires the MySQL .NET connector and access to `smapp.ini`, and will look for `smapp.ini` in the parent folder when run from the `Optional` directory.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982475d391c832bbf59083a1792f253)